### PR TITLE
Add additional instructions and clean up README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,56 @@
-# tested-transcoder   --- THIS IS A BETA RELEASE -- Please leave feedback on Github or at http://www.tested.com/forums/general-discussion/495076-transcoder-feedback/
+#tested-transcoder
+##--- THIS IS A BETA RELEASE --
+Please post feedback on github or at http://www.tested.com/forums/general-discussion/495076-transcoder-feedback/
 
-Thanks for helping us test this out! We'll have more refined instrucitons once we're sure the transcoder is ready for release.
+Thanks for helping us test this out! We'll have more refined instructions once we're sure the transcoder is ready for release.
 
 This is a vagrant script that creates a Virtualbox virtual machine that serves as a black box for transcoding and repackaging Blu-rays and DVDs ripped using MakeMKV into iTunes quality video files suitable for streaming using Plex or XBMC. It uses Don Melton's video transcoder scripts (https://github.com/donmelton/video-transcoding-scripts) to transcode individual files, but handles a lot of the tedious stuff involved in movie transcoding for you, including adding all audio tracks, selecting the proper subtitle track for non-English dialogue in English language films (Think Greedo's conversation with Han in Star Wars), handling the movie crop, etc. 
 
-To rip discs, first use MakeMKV to rip only the movie, audio tracks, and subtitles you'll need. I typically tell MakeMKV to grab all the English language subtitles and audio tracks. The process can take a long time, depending on your computer. (For reference, anything faster than 10fps is pretty good). 
-
-If you need to log into the console on the VM, the username/password is vagrant/vagrant. Once you've configured anything, the VM shouldn't need access to the network.
+To rip discs, first use MakeMKV to rip only the movie, audio tracks, and subtitles you want. The title with the most chapters, and largest size is typically the one you want. I typically tell MakeMKV to grab all the English language subtitles and audio tracks, which is a generally a good strategy. You can set this as the default in View > Preferences > Language > Preferred Language. The process may take a long time, depending on your computer and the resources you give the black box.
 
 ## Prerequisites
 
-* Virtualbox - https://www.virtualbox.org/
-* Vagrant - https://www.vagrantup.com/
+* Virtualbox - https://www.virtualbox.org/wiki/Downloads
+* Vagrant - http://www.vagrantup.com/downloads
 * Git - http://git-scm.com/downloads
-* MakeMKV - http://www.makemkv.com
-* 
+* MakeMKV - http://www.makemkv.com/download/
 
-## Install the VM
+## Installation Instructions
 
-1. Install all the prerequisites. 
-2. Rebooting is probably a good idea, especially on Windows.
-2. Navigate to your Documents folder in the terminal/command line and type 'git clone https://github.com/andymccurdy/tested-transcoder/'
-3. Switch to the tested-transcoder folder and run `vagrant up`
-4. (optional) After the script runs and your VM is created, stop it in vagrant using 'vagrant halt'. Open the VM in Virtualbox. If the VM fails to start, rebooting usually fixes the problem.
-5. Go to the VM and select settings while it isn't running. Adjust CPU and memory settings to suit. 
-6. Create a folder on the host machine where you will copy source videos to
-and collect transcoded videos from. 
-7. Use the VirtualBox UI on the host machine to share this new folder with the VM.
-    a. Click the VM named "Tested Transcoder"
-    b. Click shared folders
-    c. Click the add button
-    d. Find the folder you created in the "Folder Path" field
-    e. The "Folder Name" *must* be named "transcoder"
-    f. Check the "Make Permanent" checkbox. All the other checkboxes should be unchecked. ("Make Permanent" may or may not be visible)
-    7. Click OK and OK again to return to the VM selection screen.
-8. Wait about a minute. Input, Output and Completed Input folders should be created in the folder.
-9. Once the VM is running, starting your encodes is as easy as dragging a video from MakeMKV into the "Input" folder.
-10. When the encode is in progress, you can check in on its progress by looking in the work folder and reading the end of the log. 
-11. When the encodes are complete, the new, better compressed video will be in the Output folder and the original source MKV will be in the completed-originals folder. After you've confirmed subtitles and audio tracks are correct, you can safely delete the large original file.
-12. Enjoy your new, much smaller MKV in Plex or whatever eles you like. 
-13. Please post feedback at http://www.tested.com/forums/general-discussion/495076-transcoder-feedback/
+1. Install the prerequisites.
+2. Verify that CPU Virtualization is turned on in your BIOS. (See below for a simple test)
+3. Navigate to your Documents folder in the terminal/command line and type `git clone https://github.com/andymccurdy/tested-transcoder/`
+4. Switch to the 'tested-transcoder' folder and run `vagrant up`.
+5. Create a folder on the host machine where you will copy source videos to and collect transcoded videos from.
+6. Use the VirtualBox UI on the host machine to share this new folder with the VM.
+    1. Click the VM named "Tested Transcoder."
+    2. (Optional) Stop machine by using `vagrant halt` and adjust CPU / memory settings to suit. Once you have saved the changes start the machine again with `vagrant up`.
+    3. Click Shared folders.
+    4. Click the add button.
+    5. Find the folder you created in the "Folder Path" field.
+    6. The "Folder Name" *must* be "transcoder" or the script will not work.
+    7. Check the "Make Permanent" checkbox (may not be visible). Verify all other checkboxes are unchecked.
+    8. Click OK twice to return to the VM selection screen.
+8. Wait approximately a minute for 'input', 'output', 'work', and 'completed-originals' folders to be created in the folder on your host machine.
+
+## Usage
+
+1. While the VM is running, starting your encodes is as easy as dragging a video from MakeMKV into the 'input' folder.
+2. When the encode is in progress, you can check in on its progress by looking at the end of the log in the 'work' folder.
+3. When the encodes are complete, the new, better compressed video will be in the 'output' folder and the original source MKV will be in the 'completed-originals' folder. After you've confirmed subtitles and audio tracks are correct, you can safely delete the large original file.
+4. Enjoy your new, much smaller MKV in your favorite media player.
+
+---
+#### Verify CPU Virtualization is on
+There may be better ways to do this, but this seems to be a reasonable way.
+
+1. Open VitrualBox Manager.
+2. Select New
+3. Name: test
+4. Next.
+5. Next.
+5. Do not add a virtual hard drive.
+6. Create.
+7. Click on the test VM and look under System for "Acceleration: VT-x/AMD-V, Nested Paging."
+8. If you see this message you should be good, otherwise you will need to Google how to turn it on for your specific motherboard.
+9. Once you are finished delete the test VM. (Right Click > Remove)


### PR DESCRIPTION
I attempted to clean up a few things in the README.

Fixed a typo or two.
All prerequisite links now go directly to the download pages. 
Added a couple code blocks.
Separated Installation from Usage.

I also added a section about testing to VT-x support on the machine before attempting to use vagrant. It had somehow became disabled in my BIOS, and it broke the initial `vagrant up` without me realizing the cause. For a user less familiar to VirtualBox this could be a real problem. It might be worth considering defaulting to 1 CPU core, which would not need it, and allowing advanced users to enable multi-core support themselves. 
