### PR TITLE
Passthrough all subtitles present, no main audio reencode.

### DIFF
--- a/transcoder.py
+++ b/transcoder.py
@@ -268,6 +268,9 @@ class Transcoder(object):
             'transcode-video.sh',
             '--crop %s' % crop,
             self.parse_audio_tracks(meta),
+            '--single', # don't reencode of main audio track to stereo
+            self.parse_subtitle_tracks(meta),
+            '--no-auto-burn', # leave this to media player
             self.TRANSCODE_OPTIONS,
             '--output "%s"' % output,
             '"%s"' % path
@@ -283,6 +286,21 @@ class Transcoder(object):
             return None
         self.logger.info('Transcoding completed for input "%s"', name)
         return output
+
+    def parse_subtitle_tracks(self, meta):
+        pos = meta.find('+ subtitle tracks:')
+        track_re = r'^\s+\+\s(?P<track>[0-9]+),\s(?P<language>[^\(\n]*)'
+        # language may be useful for some kind of filter
+        subtitle_tracks = []
+        for line in meta[pos:].split('\n')[1:]:
+            if line.startswith('HandBrake'):
+                break
+            match = re.match(track_re, line)
+            if match:
+                self.logger.info('Adding subtitle track #%s (%s)',
+                                 match.group(1), match.group(2).rstrip()()
+                subtitle_tracks.append('--add-subtitle %s' % (match.group(1)))
+        return ' '.join(subtitle_tracks)
 
     def parse_audio_tracks(self, meta):
         "Parse the meta info for audio tracks beyond the first one"
@@ -308,7 +326,8 @@ class Transcoder(object):
                 break
             match = re.match(track_re, line)
             if match:
-                tracks.append({'number': match.group(1), 'title': match.group(2)})
+                tracks.append({'number': match.group(1),
+                               'title': match.group(2).rstrip()})
 
         # assuming there's an equal number of tracks and streams, we can
         # match up stream titles to tracks and have a nicer output

--- a/transcoder.py
+++ b/transcoder.py
@@ -37,7 +37,7 @@ class Transcoder(object):
     # directory contained the compressed outputs
     OUTPUT_DIRECTORY = TRANSCODER_ROOT + '/output'
     # standard options for the transcode-video script
-    TRANSCODE_OPTIONS = '--mkv --slow --allow-dts --allow-ac3 --find-forced add --copy-all-ac3'
+    TRANSCODE_OPTIONS = '--mkv --slow --allow-dts --allow-ac3 --copy-all-ac3 --single --no-auto-burn'
     # number of seconds a file must remain unmodified in the INPUT_DIRECTORY
     # before it is considered done copying. increase this value for more
     # tolerance on bad network connections.
@@ -268,9 +268,7 @@ class Transcoder(object):
             'transcode-video.sh',
             '--crop %s' % crop,
             self.parse_audio_tracks(meta),
-            '--single', # don't reencode of main audio track to stereo
             self.parse_subtitle_tracks(meta),
-            '--no-auto-burn', # leave this to media player
             self.TRANSCODE_OPTIONS,
             '--output "%s"' % output,
             '"%s"' % path
@@ -298,7 +296,7 @@ class Transcoder(object):
             match = re.match(track_re, line)
             if match:
                 self.logger.info('Adding subtitle track #%s (%s)',
-                                 match.group(1), match.group(2).rstrip()()
+                                 match.group(1), match.group(2).rstrip())
                 subtitle_tracks.append('--add-subtitle %s' % (match.group(1)))
         return ' '.join(subtitle_tracks)
 


### PR DESCRIPTION
Hopefully this is the direction you were headed. I know these are based off my personal preferences and may not completely match. The added audio track, and subtitles were important sticking points to me. With these changed I feel I can actually start doing my whole collection without having to go back and redo them later. This branch will also merge and work with #3, which is how I have been testing it. I moved it to its own branch in order to keep the pulls separate.

Added `--single` to stop reencoding the main AC3 as AAC. I do not feel that it is necessary to recreate the 5.1 audio as stereo within the transcode, media players can handle it on the fly. This seems to shave ~~almost 1GB from the~~ about 100MB file size, as well as some time. Not a huge deal, but it does help.

Changed code to passthrough all subtitles which are present in the mkv. This means there is no need to intelligently decide what subtitles are wanted in the program. Whichever subtitles are ripped will end up in the final mkv exactly as they show up in the original. The regex does allow for some language filtering later if that is a direction that is interesting. It would require more configuration and be slightly less turnkey though. I am leaning towards allow the user to decide while ripping it.

Added `--no-auto-burn` because I think it is better to leave the subtitles as text. They are now passed through so they still have the 'forced' tag for whatever media player you use to display them. This may still need more testing, my two test movies have not had any forced.
